### PR TITLE
fix: various `renovate` config changes

### DIFF
--- a/template/.github/renovate.json5.copier-jinja
+++ b/template/.github/renovate.json5.copier-jinja
@@ -34,7 +34,7 @@
   "packageRules": [
 {%- if release_is_scheduled %}
     {
-      "matchFiles": [".schedule-version"],
+      "matchFileNames": [".schedule-version"],
       "extends": [
         ":semanticPrefixFix",
         "schedule:weekly",

--- a/template/.github/renovate.json5.copier-jinja
+++ b/template/.github/renovate.json5.copier-jinja
@@ -51,5 +51,4 @@
       "automerge": true,
     },
   ],
-  "platformAutomerge": false,
 }

--- a/template/.github/renovate.json5.copier-jinja
+++ b/template/.github/renovate.json5.copier-jinja
@@ -2,6 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": [
     "copier",
+{%- if release_is_scheduled %}
+    "custom.regex",
+{%- endif %}
     "git-submodules",
   ],
   "extends": [

--- a/test/GenerateProject/renovate_json5.tt
+++ b/test/GenerateProject/renovate_json5.tt
@@ -17,5 +17,4 @@
       "automerge": true,
     },
   ],
-  "platformAutomerge": false,
 }

--- a/test/PublishToDockerHub/renovate_json5.tt
+++ b/test/PublishToDockerHub/renovate_json5.tt
@@ -17,5 +17,4 @@
       "automerge": true,
     },
   ],
-  "platformAutomerge": false,
 }

--- a/test/PublishToGitLabRegistry/renovate_json5.tt
+++ b/test/PublishToGitLabRegistry/renovate_json5.tt
@@ -17,5 +17,4 @@
       "automerge": true,
     },
   ],
-  "platformAutomerge": false,
 }

--- a/test/ScheduleARelease/renovate_json5.tt
+++ b/test/ScheduleARelease/renovate_json5.tt
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": [
     "copier",
+    "custom.regex",
     "git-submodules",
   ],
   "extends": [

--- a/test/ScheduleARelease/renovate_json5.tt
+++ b/test/ScheduleARelease/renovate_json5.tt
@@ -43,5 +43,4 @@
       "automerge": true,
     },
   ],
-  "platformAutomerge": false,
 }

--- a/test/ScheduleARelease/renovate_json5.tt
+++ b/test/ScheduleARelease/renovate_json5.tt
@@ -27,7 +27,7 @@
   },
   "packageRules": [
     {
-      "matchFiles": [".schedule-version"],
+      "matchFileNames": [".schedule-version"],
       "extends": [
         ":semanticPrefixFix",
         "schedule:weekly",

--- a/test/SetImageAuthors/renovate_json5.tt
+++ b/test/SetImageAuthors/renovate_json5.tt
@@ -17,5 +17,4 @@
       "automerge": true,
     },
   ],
-  "platformAutomerge": false,
 }

--- a/test/SetImageNamespace/renovate_json5.tt
+++ b/test/SetImageNamespace/renovate_json5.tt
@@ -17,5 +17,4 @@
       "automerge": true,
     },
   ],
-  "platformAutomerge": false,
 }

--- a/test/SetImageRepo/renovate_json5.tt
+++ b/test/SetImageRepo/renovate_json5.tt
@@ -17,5 +17,4 @@
       "automerge": true,
     },
   ],
-  "platformAutomerge": false,
 }


### PR DESCRIPTION
- **fix: `custom.regex` manager is required for scheduled releases**
- **fix: `platformAutomerge` unnecessary as it's only enabled if enabled in the GH repo**
- **test: approve new changes**
- **fix: migrate config to use `matchFileNames`**
